### PR TITLE
home_mailbox parameter and create_resources(mastercf)

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -59,8 +59,11 @@ class postfix::config (
   $maildrop_destination_recipient_limit = undef,
   $dovecot_destination_recipient_limit  = undef,
   $luser_relay                          = undef,
+  $mastercfs                            = {},
 ) {
   include postfix
+
+  create_resources(postfix::config::mastercf, $mastercfs)
 
   postfix::config::maincfhelper { 'luser_relay': value => $luser_relay, }
 


### PR DESCRIPTION
Sorry this isn't on two separate feature branches, I can do that if you need. This simply adds the `home_mailbox` parameter for Postfix, and adds a `config::mastercfs` hash that is passed to the create_resources function, which lets you create as many `postfix::config::mastercf` resources as you want from, say, hiera. Tested and works.
