### PR TITLE
Couple more parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -40,6 +40,7 @@ class postfix::config (
   $smtp_tls_CAfile                      = undef,
   $smtp_tls_note_starttls_offer         = undef,
   $smtp_use_tls                         = undef,
+  $soft_bounce                          = undef,
   $strict_rfc821_envelopes              = undef,
   $tls_random_source                    = undef,
   $transport_maps                       = undef,
@@ -155,6 +156,8 @@ class postfix::config (
   postfix::config::maincfhelper { 'smtp_tls_note_starttls_offer': value => $smtp_tls_note_starttls_offer }
 
   postfix::config::maincfhelper { 'smtp_use_tls': value => $smtp_use_tls }
+
+  postfix::config::maincfhelper { 'soft_bounce': value => $soft_bounce }
 
   postfix::config::maincfhelper { 'strict_rfc821_envelopes': value => $strict_rfc821_envelopes }
 


### PR DESCRIPTION
Wow, a nice clean PR! This adds the `soft_bounce` (useful when testing) and `strict_rfc821_envelopes` (desired as an anti-spam measure) parameters.
