### PR TITLE
More parameters + Hiera creation of parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,10 +75,13 @@ class postfix::config (
   $dovecot_destination_recipient_limit  = undef,
   $luser_relay                          = undef,
   $mastercfs                            = {},
+  $maincfs                              = {},
 ) {
   include postfix
 
-  create_resources(postfix::config::mastercf, $mastercfs)
+  create_resources(postfix::config::mastercf, hiera_hash('postfix::config::mastercfs', {}))
+
+  create_resources(postfix::config::maincfhelper, hiera_hash('postfix::config::maincfs', {}))
 
   postfix::config::maincfhelper { 'mailbox_transport': value => $mailbox_transport, }
 


### PR DESCRIPTION
This adds the oft-used parameters `mailbox_command` and `mailbox_transport`, and also adds a hash `maincfs` that can be used in Hiera to create arbitrary `postfix::config::maincfhelper` resources (say, for missing parameters).

In YAML, this could be:

``` yaml
postfix::config::maincfs:
  mailbox_transport:
    value: lmtp:unix:/var/spool/postfix/private/dovecot-lmtp
```

I should note that the Puppet compilation will fail if we have already defined that parameter in `config.pp`, so perhaps we should think of removing all those that are defaulted to `undef`... and just checked, that's all of them. Hm. Thoughts? (This doesn't block this pull-request.)
