### PR TITLE
add quoting, since command may include options

### DIFF
--- a/manifests/config/mastercf.pp
+++ b/manifests/config/mastercf.pp
@@ -34,7 +34,7 @@ define postfix::config::mastercf (
           "set ${name}/chroot ${chroot}",
           "set ${name}/wakeup ${wakeup}",
           "set ${name}/limit ${limit}",
-          "set ${name}/command ${command}",
+          "set ${name}/command '${command}'",
           ],
       }
     }


### PR DESCRIPTION
without quotes, augeas will only add single word. 
