### PR TITLE
include fqdn in mydestination

### DIFF
--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -29,7 +29,12 @@ class postfix::relay (
 
   postfix::config::maincfhelper { 'myorigin': value => $sender_hostname, }
 
-  postfix::config::maincfhelper { 'mydestination': value => "${sender_hostname}, ${::hostname}, localhost.localdomain, localhost", }
+  if $::fqdn != $sender_hostname {
+    postfix::config::maincfhelper { 'mydestination': value => "${sender_hostname}, ${::fqdn}, ${::hostname}, localhost.localdomain, localhost", }
+  }
+  else {
+    postfix::config::maincfhelper { 'mydestination': value => "${sender_hostname}, ${::hostname}, localhost.localdomain, localhost", }
+  }
 
   postfix::config::maincfhelper { 'relayhost': value => $relayhost, }
 


### PR DESCRIPTION
When using a different sender_hostname than fqdn, then include fqdn in mydestination.
