### PR TITLE
Add parameters to config.pp

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,6 +10,7 @@
 #
 # mjhas@github
 class postfix::config (
+  $default_transport                    = undef,
   $mailbox_transport                    = undef,
   $mailbox_command                      = undef,
   $alias_maps                           = undef,
@@ -86,6 +87,8 @@ class postfix::config (
   include postfix
 
   create_resources(postfix::config::mastercf, $mastercfs)
+
+  postfix::config::maincfhelper { 'default_transport': value => $default_transport, }
 
   postfix::config::maincfhelper { 'mailbox_transport': value => $mailbox_transport, }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -75,6 +75,12 @@ class postfix::config (
   $maildrop_destination_recipient_limit = undef,
   $dovecot_destination_recipient_limit  = undef,
   $luser_relay                          = undef,
+  $relay_domains                        = undef,
+  $relay_transport                      = undef,
+  $inet_protocols                       = undef,
+  $smtp_address_preference              = undef,
+  $masquerade_domains                   = undef,
+  $proxy_interfaces                     = undef,
   $mastercfs                            = {},
 ) {
   include postfix
@@ -210,4 +216,16 @@ class postfix::config (
   postfix::config::maincfhelper { 'virtual_overquota_bounce': value => $virtual_overquota_bounce }
 
   postfix::config::maincfhelper { 'virtual_uid_maps': value => $virtual_uid_maps }
+
+  postfix::config::maincfhelper { 'relay_domains': value => $relay_domains }
+
+  postfix::config::maincfhelper { 'relay_transport': value => $relay_transport }
+
+  postfix::config::maincfhelper { 'inet_protocols': value => $inet_protocols }
+
+  postfix::config::maincfhelper { 'smtp_address_preference': value => $smtp_address_preference }
+
+  postfix::config::maincfhelper { 'masquerade_domains': value => $masquerade_domains }
+
+  postfix::config::maincfhelper { 'proxy_interfaces': value => $proxy_interfaces }
 }

--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -20,6 +20,7 @@ class postfix::relay (
   $smtp_tls_note_starttls_offer = undef,
   $smtp_tls_security_level = undef,
   $smtp_use_tls = undef,
+  $transport_maps = undef,
 ) {
   include postfix
 
@@ -54,4 +55,6 @@ class postfix::relay (
   postfix::config::maincfhelper { 'masquerade_domains': value => $masquerade_domains, }
 
   postfix::config::maincfhelper { 'inet_interfaces': value => 'loopback-only', }
+
+  postfix::config::maincfhelper { 'transport_maps': value => $transport_maps }
 }

--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -20,7 +20,7 @@ class postfix::relay (
   $smtp_tls_note_starttls_offer = undef,
   $smtp_tls_security_level = undef,
   $smtp_use_tls = undef,
-  $transport_maps = undef,
+  $transport_maps = 'hash:/etc/postfix/transport',
 ) {
   include postfix
 

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,7 @@
   "author": "mjhas",
   "summary": "This Postfix Module installs postfix and configures it using Augeas",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":"4.3.2"}
+    {"name":"puppetlabs/stdlib","version_requirement":">=4.3.2"}
   ],
   "source": "https://github.com/mjhas/postfix.git",
   "project_page": "https://github.com/mjhas/postfix",


### PR DESCRIPTION
There are a number of parameters that I would like to use in config.pp that were not there. These parameters are relay_domains, relay_transport, inet_protocols, smtp_address_preference, masquerade_domains, proxy_interfaces.  I did not see any corresponding spec tests for the current params so I didn't add any for these.
