### PR TITLE
Allow setting inet_interfaces in relay.pp

### DIFF
--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -21,6 +21,7 @@ class postfix::relay (
   $smtp_tls_security_level = undef,
   $smtp_use_tls = undef,
   $inet_interfaces = 'loopback-only',
+  $inet_protocols  = 'all',
 ) {
   include postfix
 

--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -20,7 +20,7 @@ class postfix::relay (
   $smtp_tls_note_starttls_offer = undef,
   $smtp_tls_security_level = undef,
   $smtp_use_tls = undef,
-  $inet_interfaces = 'loopbback-only',
+  $inet_interfaces = 'loopback-only',
 ) {
   include postfix
 

--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -56,4 +56,6 @@ class postfix::relay (
   postfix::config::maincfhelper { 'masquerade_domains': value => $masquerade_domains, }
 
   postfix::config::maincfhelper { 'inet_interfaces': value => $inet_interfaces, }
+
+  postfix::config::maincfhelper { 'inet_protocols': value => $inet_protocols, }
 }

--- a/manifests/relay.pp
+++ b/manifests/relay.pp
@@ -20,6 +20,7 @@ class postfix::relay (
   $smtp_tls_note_starttls_offer = undef,
   $smtp_tls_security_level = undef,
   $smtp_use_tls = undef,
+  $inet_interfaces = 'loopbback-only',
 ) {
   include postfix
 
@@ -53,5 +54,5 @@ class postfix::relay (
 
   postfix::config::maincfhelper { 'masquerade_domains': value => $masquerade_domains, }
 
-  postfix::config::maincfhelper { 'inet_interfaces': value => 'loopback-only', }
+  postfix::config::maincfhelper { 'inet_interfaces': value => $inet_interfaces, }
 }


### PR DESCRIPTION
We have a requirement that inet_interfaces be set to a specific value. This allows it to be set in relay.pp
